### PR TITLE
Tag Input and Account Switcher UI

### DIFF
--- a/src/app/mail/account-switcher.tsx
+++ b/src/app/mail/account-switcher.tsx
@@ -11,6 +11,7 @@ import { getAurinkoAuthUrl } from "@/lib/aurinko";
 import { cn } from "@/lib/utils";
 import { api } from "@/trpc/react";
 import { PlusIcon } from "@radix-ui/react-icons";
+import { useRouter } from "next/navigation";
 import React, { useState } from "react";
 import { useLocalStorage } from "usehooks-ts";
 
@@ -20,6 +21,7 @@ type Props = {
 
 const AccountSwitcher = ({ isCollapsed }: Props) => {
   const { data } = api.account.getAccounts.useQuery();
+  const router = useRouter();
 
   const [accountId, setAccountId] = useLocalStorage("accountId", "");
 
@@ -62,10 +64,9 @@ const AccountSwitcher = ({ isCollapsed }: Props) => {
           ))}
           <div
             onClick={async () => {
-              const authUrl = await getAurinkoAuthUrl("Google");
-              window.location.href = authUrl;
+              router.push("/");
             }}
-            className="relative flex w-full cursor-pointer items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none hover:bg-gray-50 focus:bg-accent"
+            className="focus:bg-accen relative flex w-full cursor-pointer items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none hover:bg-gray-50 dark:hover:bg-zinc-800"
           >
             <PlusIcon className="mr-1 size-4" />
             Add Account

--- a/src/app/mail/tag-input.tsx
+++ b/src/app/mail/tag-input.tsx
@@ -25,7 +25,7 @@ const TagInput = ({ placeholder, label, onChange, value }: Props) => {
 
   const options = suggestions?.map((s) => ({
     label: (
-      <span className="flex items-center gap-2">
+      <span className="flex items-center gap-2 dark:text-white">
         <Avatar size="25" name={s.address} textSizeRatio={2} round />
         {s.address}
       </span>
@@ -56,10 +56,16 @@ const TagInput = ({ placeholder, label, onChange, value }: Props) => {
             return "!border-none !outline-none !ring-0 !shadow-none focus:border-none focus:outline-none focus:ring-0 focus:shadow-none dark:bg-transparent";
           },
           multiValue: () => {
-            return "dark:!bg-gray-700";
+            return "dark:bg-gray-700";
           },
           multiValueLabel: () => {
             return "dark:text-white dark:bg-gray-700 rounded-md";
+          },
+          menuList: () => {
+            return "dark:bg-gray-800";
+          },
+          option: () => {
+            return "dark:bg-gray-800 hover:dark:bg-gray-500";
           },
         }}
       />


### PR DESCRIPTION
This pull request includes updates to improve the navigation and user interface in the account switcher and tag input components. The most important changes are the addition of the `useRouter` hook for navigation and enhancements to the dark mode styling.

### Navigation Improvements:
* [`src/app/mail/account-switcher.tsx`](diffhunk://#diff-bb0cd7a3b892d537c0102167e84073f36549262fe345c1150d2bd256bceea280R14): Added `useRouter` from `next/navigation` and replaced the `window.location.href` with `router.push("/")` for navigation. [[1]](diffhunk://#diff-bb0cd7a3b892d537c0102167e84073f36549262fe345c1150d2bd256bceea280R14) [[2]](diffhunk://#diff-bb0cd7a3b892d537c0102167e84073f36549262fe345c1150d2bd256bceea280R24) [[3]](diffhunk://#diff-bb0cd7a3b892d537c0102167e84073f36549262fe345c1150d2bd256bceea280L65-R69)

### Dark Mode Enhancements:
* [`src/app/mail/tag-input.tsx`](diffhunk://#diff-5b89dff9253ca52d22d6331fb2a3875e2bb7292c6b096d1c3c96792fbd8886f6L28-R28): Updated the `TagInput` component to include additional dark mode styles for various elements like `menuList` and `option`. [[1]](diffhunk://#diff-5b89dff9253ca52d22d6331fb2a3875e2bb7292c6b096d1c3c96792fbd8886f6L28-R28) [[2]](diffhunk://#diff-5b89dff9253ca52d22d6331fb2a3875e2bb7292c6b096d1c3c96792fbd8886f6L59-R69)