### PR TITLE
Adding Mark as Read Backend

### DIFF
--- a/src/app/mail/email-editor.tsx
+++ b/src/app/mail/email-editor.tsx
@@ -1,18 +1,25 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
+import { readStreamableValue } from "ai/rsc";
+
+// tiptap text-editor
 import { EditorContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import { Text } from "@tiptap/extension-text";
-import EditorMenuBar from "./editor-menubar";
+
+// components
 import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import TagInput from "./tag-input";
-import AIComposeButton from "./ai-conpose-button";
-import { generate } from "./action";
-import { readStreamableValue } from "ai/rsc";
+import TagInput from "@/app/mail/tag-input";
+import AIComposeButton from "@/app/mail/ai-conpose-button";
+import EditorMenuBar from "@/app/mail/editor-menubar";
 
+// actions
+import { generate } from "@/app/mail/action";
+
+// types
 type Props = {
   subject: string;
   setSubject: (value: string) => void;

--- a/src/app/mail/mail.tsx
+++ b/src/app/mail/mail.tsx
@@ -1,26 +1,35 @@
 "use client";
 
 import React, { useState } from "react";
+import dynamic from "next/dynamic";
+
+// clerk
+import { UserButton } from "@clerk/nextjs";
+
+// components
+import ThreadDisplay from "@/app/mail/thread-display";
+import AccountSwitcher from "@/app/mail/account-switcher";
+import Sidebar from "@/app/mail/sidebar";
+import ThreadList from "@/app/mail/thread-list";
+import SearchBar from "@/app/mail/search-bar";
+import AskAI from "@/app/mail/ask-ai";
+import { Separator } from "@/components/ui/separator";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
 } from "@/components/ui/resizable";
-import { TooltipProvider } from "@radix-ui/react-tooltip";
-import { Separator } from "@/components/ui/separator";
-import { cn } from "@/lib/utils";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import AccountSwitcher from "./account-switcher";
-import Sidebar from "./sidebar";
-import ThreadList from "./thread-list";
-import ThreadDisplay from "./thread-display";
-import { UserButton } from "@clerk/nextjs";
 import { ModeToggle } from "@/components/dark-mode-toggle";
-import dynamic from "next/dynamic";
-import SearchBar from "./search-bar";
-import AskAI from "./ask-ai";
+
+// utils
+import { cn } from "@/lib/utils";
+
+// dynamic imports
 const ComposeButton = dynamic(() => import("./compose-button"), { ssr: false });
 
+// types
 type Props = {
   defaultLayout: number[] | undefined;
   navCollapsedSize: number;

--- a/src/app/mail/thread-display.tsx
+++ b/src/app/mail/thread-display.tsx
@@ -3,20 +3,11 @@
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import useThreads from "@/hooks/use-threads";
-import {
-  Archive,
-  ArchiveX,
-  Clock,
-  MoreVertical,
-  MoreVerticalIcon,
-  Trash2,
-} from "lucide-react";
+import { Archive, ArchiveX, Clock, MoreVertical, Trash2 } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 
@@ -34,6 +25,9 @@ type Props = {};
 const ThreadDisplay = (props: Props) => {
   const { threadId, threads } = useThreads();
   const thread = threads?.find((t) => t.id === threadId);
+
+  // TODO - take out all the messageIds from the current thread here and call the mark as read fn on them
+  // TODO - for a Single message handle the mark as read as well!
 
   const [isSearching] = useAtom(isSearchingAtom);
 

--- a/src/server/api/routers/account.ts
+++ b/src/server/api/routers/account.ts
@@ -410,4 +410,37 @@ export const accountRouter = createTRPCRouter({
       const results = await orama.search({ term: input.query });
       return results;
     }),
+
+  // NOTE - Same APIs can be used for a single single message as by passing the single message id in the messageIds array
+  markAsRead: privateProcedure
+    .input(
+      z.object({
+        accountId: z.number(),
+        messageIds: z.array(z.string()),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const account = await authorizeAccountAccess(
+        input.accountId,
+        ctx.auth.userId,
+      );
+      const acc = new Account(account.accessToken);
+      await acc.markAsRead(input.messageIds, false);
+    }),
+
+  markAsUnRead: privateProcedure
+    .input(
+      z.object({
+        accountId: z.number(),
+        messageIds: z.array(z.string()),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const account = await authorizeAccountAccess(
+        input.accountId,
+        ctx.auth.userId,
+      );
+      const acc = new Account(account.accessToken);
+      await acc.markAsRead(input.messageIds, true);
+    }),
 });


### PR DESCRIPTION
This pull request includes several changes to improve the code organization, enhance functionality, and update dependencies in the email-related components and services. The most important changes include refactoring imports for better clarity, adding new methods for marking emails as read/unread, and updating API endpoint usage.

### Code Organization:

* Refactored imports in `src/app/mail/email-editor.tsx` to group them by type (components, actions, types) and updated import paths for consistency.
* Refactored imports in `src/app/mail/mail.tsx` to group them by type (clerk, components, utils, dynamic imports) and updated import paths for consistency.
* Simplified imports in `src/app/mail/thread-display.tsx` by removing unused imports and consolidating related imports.

### New Functionality:

* Added a `markAsRead` method in `src/lib/account.ts` to mark emails as read in both the Aurinko API and the database.
* Added `markAsRead` and `markAsUnRead` mutations in `src/server/api/routers/account.ts` to handle marking emails as read/unread via API.

### API Endpoint Updates:

* Updated API endpoint usage in `src/lib/account.ts` to use a class property for the base URL (`AURINKO_URL`). [[1]](diffhunk://#diff-852142dc12d33a94e50f06684ad772367f61da96e0db777c7ff4db916c174ab3R24) [[2]](diffhunk://#diff-852142dc12d33a94e50f06684ad772367f61da96e0db777c7ff4db916c174ab3L39-R40) [[3]](diffhunk://#diff-852142dc12d33a94e50f06684ad772367f61da96e0db777c7ff4db916c174ab3L82-R83) [[4]](diffhunk://#diff-852142dc12d33a94e50f06684ad772367f61da96e0db777c7ff4db916c174ab3L273-R274)

### Miscellaneous:

* Added TODO comments in `src/app/mail/thread-display.tsx` for future improvements related to marking messages as read.